### PR TITLE
Remove legacy style constructors

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -27,10 +27,6 @@ class Config
 	var $name, $page; // Page name
 	var $objs = array();
 
-	function Config($name)
-	{
-		$this->__construct($name);
-	}
 	function __construct($name)
 	{
 		$this->name = $name;
@@ -139,10 +135,6 @@ class ConfigTable
 	var $after  = array();	// Page contents (except table ones)
 	var $values = array();	// Table contents
 
-	function ConfigTable($title, $obj = NULL)
-	{
-		$this->__construct($title, $obj);
-	}
 	function __construct($title, $obj = NULL)
 	{
 		if ($obj !== NULL) {

--- a/lib/convert_html.php
+++ b/lib/convert_html.php
@@ -32,10 +32,6 @@ class Element
 	var $elements; // References of childs
 	var $last;     // Insert new one at the back of the $last
 
-	function Element()
-	{
-		$this->__construct();
-	}
 	function __construct()
 	{
 		$this->elements = array();
@@ -169,10 +165,6 @@ function & Factory_Div(& $root, $text)
 // Inline elements
 class Inline extends Element
 {
-	function Inline($text)
-	{
-		$this->__construct($text);
-	}
 	function __construct($text)
 	{
 		parent::__construct();
@@ -210,10 +202,6 @@ class Paragraph extends Element
 {
 	var $param;
 
-	function Paragraph($text, $param = '')
-	{
-		$this->__construct($text, $param);
-	}
 	function __construct($text, $param = '')
 	{
 		parent::__construct();
@@ -246,10 +234,6 @@ class Heading extends Element
 	var $id;
 	var $msg_top;
 
-	function Heading(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		parent::__construct();
@@ -282,10 +266,6 @@ class Heading extends Element
 // Horizontal Rule
 class HRule extends Element
 {
-	function HRule(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		parent::__construct();
@@ -311,10 +291,6 @@ class ListContainer extends Element
 	var $level;
 	var $style;
 
-	function ListContainer($tag, $tag2, $head, $text)
-	{
-		$this->__construct($tag, $tag2, $head, $text);
-	}
 	function __construct($tag, $tag2, $head, $text)
 	{
 		parent::__construct();
@@ -370,10 +346,6 @@ class ListContainer extends Element
 
 class ListElement extends Element
 {
-	function ListElement($level, $head)
-	{
-		$this->__construct($level, $head);
-	}
 	function __construct($level, $head)
 	{
 		parent::__construct();
@@ -397,10 +369,6 @@ class ListElement extends Element
 // - Three
 class UList extends ListContainer
 {
-	function UList(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		parent::__construct('ul', 'li', '-', $text);
@@ -412,10 +380,6 @@ class UList extends ListContainer
 // + Three
 class OList extends ListContainer
 {
-	function OList(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		parent::__construct('ol', 'li', '+', $text);
@@ -427,10 +391,6 @@ class OList extends ListContainer
 // : definition3 | description3
 class DList extends ListContainer
 {
-	function DList($out)
-	{
-		$this->__construct($out);
-	}
 	function __construct($out)
 	{
 		parent::__construct('dl', 'dt', ':', $out[0]);
@@ -446,10 +406,6 @@ class BQuote extends Element
 {
 	var $level;
 
-	function BQuote(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		parent::__construct();
@@ -513,10 +469,6 @@ class TableCell extends Element
 	var $rowspan = 1;
 	var $style; // is array('width'=>, 'align'=>...);
 
-	function TableCell($text, $is_template = FALSE)
-	{
-		$this->__construct($text, $is_template);
-	}
 	function __construct($text, $is_template = FALSE)
 	{
 		parent::__construct();
@@ -597,10 +549,6 @@ class Table extends Element
 	var $types;
 	var $col; // number of column
 
-	function Table($out)
-	{
-		$this->__construct($out);
-	}
 	function __construct($out)
 	{
 		parent::__construct();
@@ -702,10 +650,6 @@ class YTable extends Element
 {
 	var $col;	// Number of columns
 
-	function YTable($row = array('cell1 ', ' cell2 ', ' cell3'))
-	{
-		$this->__construct($row);
-	}
 	// TODO: Seems unable to show literal '==' without tricks.
 	//       But it will be imcompatible.
 	// TODO: Why toString() or toXHTML() here
@@ -782,10 +726,6 @@ class YTable extends Element
 // ' 'Space-beginning sentence
 class Pre extends Element
 {
-	function Pre(& $root, $text)
-	{
-		$this->__construct($root, $text);
-	}
 	function __construct(& $root, $text)
 	{
 		global $preformat_ltrim;
@@ -817,10 +757,6 @@ class Div extends Element
 	var $name;
 	var $param;
 
-	function Div($out)
-	{
-		$this->__construct($out);
-	}
 	function __construct($out)
 	{
 		parent::__construct();
@@ -844,10 +780,6 @@ class Align extends Element
 {
 	var $align;
 
-	function Align($align)
-	{
-		$this->__construct($align);
-	}
 	function __construct($align)
 	{
 		parent::__construct();
@@ -883,10 +815,6 @@ class Body extends Element
 		',' => 'YTable',
 		'#' => 'Div');
 
-	function Body($id)
-	{
-		$this->__construct($id);
-	}
 	function __construct($id)
 	{
 		$this->id            = $id;
@@ -1036,10 +964,6 @@ class Body extends Element
 
 class Contents_UList extends ListContainer
 {
-	function Contents_UList($text, $level, $id)
-	{
-		$this->__construct($text, $level, $id);
-	}
 	function __construct($text, $level, $id)
 	{
 		// Reformatting $text

--- a/lib/diff.php
+++ b/lib/diff.php
@@ -99,10 +99,6 @@ class line_diff
 {
 	var $arr1, $arr2, $m, $n, $pos, $key, $plus, $minus, $equal, $reverse;
 
-	function line_diff($plus = '+', $minus = '-', $equal = ' ')
-	{
-		$this->__construct($plus, $minus, $equal);
-	}
 	function __construct($plus = '+', $minus = '-', $equal = ' ')
 	{
 		$this->plus  = $plus;
@@ -258,10 +254,6 @@ class DiffLine
 	var $text;
 	var $status;
 
-	function DiffLine($text)
-	{
-		$this->__construct($text);
-	}
 	function __construct($text)
 	{
 		$this->text   = $text . "\n";

--- a/lib/make_link.php
+++ b/lib/make_link.php
@@ -69,10 +69,6 @@ class InlineConverter
 		$this->converters = $converters;
 	}
 
-	function InlineConverter($converters = NULL, $excludes = NULL)
-	{
-		$this->__construct($converters, $excludes);
-	}
 	function __construct($converters = NULL, $excludes = NULL)
 	{
 		if ($converters === NULL) {
@@ -176,10 +172,6 @@ class Link
 	var $body;
 	var $alias;
 
-	function Link($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		$this->start = $start;
@@ -238,10 +230,6 @@ class Link_plugin extends Link
 	var $pattern;
 	var $plain,$param;
 
-	function Link_plugin($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -311,10 +299,6 @@ EOD;
 // Footnotes
 class Link_note extends Link
 {
-	function Link_note($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -381,10 +365,6 @@ EOD;
 // URLs
 class Link_url extends Link
 {
-	function Link_url($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -432,10 +412,6 @@ EOD;
 // URLs (InterWiki definition on "InterWikiName")
 class Link_url_interwiki extends Link
 {
-	function Link_url_interwiki($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -476,10 +452,6 @@ class Link_mailto extends Link
 {
 	var $is_image, $image;
 
-	function Link_mailto($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -522,10 +494,6 @@ class Link_interwikiname extends Link
 	var $param  = '';
 	var $anchor = '';
 
-	function Link_interwikiname($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -593,10 +561,6 @@ class Link_bracketname extends Link
 {
 	var $anchor, $refer;
 
-	function Link_bracketname($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -659,10 +623,6 @@ EOD;
 // WikiNames
 class Link_wikiname extends Link
 {
-	function Link_wikiname($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -704,10 +664,6 @@ class Link_autolink extends Link
 	var $auto;
 	var $auto_a; // alphabet only
 
-	function Link_autolink($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		global $autolink;
@@ -754,10 +710,6 @@ class Link_autolink extends Link
 
 class Link_autolink_a extends Link_autolink
 {
-	function Link_autolink_a($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);
@@ -777,10 +729,6 @@ class Link_autoalias extends Link
 	var $auto_a; // alphabet only
 	var $alias;
 
-	function Link_autoalias($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		global $autoalias, $aliaspage;
@@ -829,10 +777,6 @@ class Link_autoalias extends Link
 
 class Link_autoalias_a extends Link_autoalias
 {
-	function Link_autoalias_a($start)
-	{
-		$this->__construct($start);
-	}
 	function __construct($start)
 	{
 		parent::__construct($start);

--- a/plugin/attach.inc.php
+++ b/plugin/attach.inc.php
@@ -441,10 +441,6 @@ class AttachFile
 	var $size_str = '';
 	var $status = array('count'=>array(0), 'age'=>'', 'pass'=>'', 'freeze'=>FALSE);
 
-	function AttachFile($page, $file, $age = 0)
-	{
-		$this->__construct($page, $file, $age);
-	}
 	function __construct($page, $file, $age = 0)
 	{
 		$this->page = $page;
@@ -758,10 +754,6 @@ class AttachFiles
 	var $page;
 	var $files = array();
 
-	function AttachFiles($page)
-	{
-		$this->__construct($page);
-	}
 	function __construct($page)
 	{
 		$this->page = $page;
@@ -836,10 +828,6 @@ class AttachPages
 {
 	var $pages = array();
 
-	function AttachPages($page = '', $age = NULL)
-	{
-		$this->__construct($page, $age);
-	}
 	function __construct($page = '', $age = NULL)
 	{
 

--- a/plugin/dump.inc.php
+++ b/plugin/dump.inc.php
@@ -340,9 +340,6 @@ class tarlib
 	var $arc_kind;
 	var $dummydata;
 
-	function tarlib() {
-		$this->__construct();
-	}
 	function __construct() {
 		$this->filename = '';
 		$this->fp       = FALSE;

--- a/plugin/map.inc.php
+++ b/plugin/map.inc.php
@@ -104,10 +104,6 @@ class MapNode
 	var $done;
 	var $hide_pattern;
 
-	function MapNode($page, $reverse = FALSE)
-	{
-		$this->__construct($page, $reverse);
-	}
 	function __construct($page, $reverse = FALSE)
 	{
 		global $non_list;

--- a/plugin/showrss.inc.php
+++ b/plugin/showrss.inc.php
@@ -84,10 +84,6 @@ class ShowRSS_html
 	var $items = array();
 	var $class = '';
 
-	function ShowRSS_html($rss)
-	{
-		$this->__construct($rss);
-	}
 	function __construct($rss)
 	{
 		foreach ($rss as $date=>$items) {

--- a/plugin/tracker.inc.php
+++ b/plugin/tracker.inc.php
@@ -273,10 +273,6 @@ class Tracker_field
 	var $sort_type = SORT_REGULAR;
 	var $id = 0;
 
-	function Tracker_field($field,$page,$refer,&$config)
-	{
-		$this->__construct($field, $page, $refer, $config);
-	}
 	function __construct($field,$page,$refer,&$config)
 	{
 		global $post;
@@ -384,10 +380,6 @@ class Tracker_field_format extends Tracker_field
 	var $styles = array();
 	var $formats = array();
 
-	function Tracker_field_format($field,$page,$refer,&$config)
-	{
-		$this->__construct($field, $page, $refer, $config);
-	}
 	function __construct($field,$page,$refer,&$config)
 	{
 		parent::__construct($field,$page,$refer,$config);
@@ -779,10 +771,6 @@ class Tracker_list
 	var $newly_deleted_pages = array();
 	var $newly_updated_pages = array();
 
-	function Tracker_list($page,$refer,&$config,$list,&$cache_holder)
-	{
-		$this->__construct($page, $refer, $config, $list, $cache_holder);
-	}
 	function __construct($page,$refer,&$config,$list,&$cache_holder)
 	{
 		global $whatsdeleted, $_cached_page_filetime;


### PR DESCRIPTION
Legacy style constructors are no longer needed, as they are deprecated in PHP 7[^1] and ignored in PHP 8[^2].
Removing them is safe and does not change how the code works. These were only for PHP 4.x compatibility.

[^1]: https://www.php.net/manual/en/migration70.deprecated.php  
[^2]: https://www.php.net/manual/en/migration80.incompatible.php  

related: #7 
